### PR TITLE
macOS build fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           arch: clang_64
           dir: ${{github.workspace}}/qt
           cache: true
-          setup-python: false
+          setup-python: true
 
       - name: "Add Qt to PATH"
         if: ${{ matrix.qt != 'qt_no' }}
@@ -159,7 +159,7 @@ jobs:
         run: |
           QT_SEARCH_MODE=$([[ "${{ matrix.qt }}" == "qt_no" ]] && echo "Skip" || echo "Force")
           
-          cmake -DSUITABLE_STRUCT_ENABLE_TESTS=ON -DSUITABLE_STRUCT_ENABLE_BENCHMARK=ON -DSUITABLE_STRUCT_QT_SEARCH_MODE:STRING=$QT_SEARCH_MODE -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -G "Unix Makefiles" -S "./src" -B "./build"
+          cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 -DSUITABLE_STRUCT_ENABLE_TESTS=ON -DSUITABLE_STRUCT_ENABLE_BENCHMARK=ON -DSUITABLE_STRUCT_QT_SEARCH_MODE:STRING=$QT_SEARCH_MODE -DCMAKE_BUILD_TYPE="${{matrix.build_type}}" -G "Unix Makefiles" -S "./src" -B "./build"
           cmake --build "./build" --config "${{matrix.build_type}}" -j "${{env.CORES}}"
           cd ./build/tests
           ctest --no-tests=error --rerun-failed --output-on-failure --timeout 30 -C "${{matrix.build_type}}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,3 @@
-# Disable warning
-# "Compatibility with CMake < 3.5 will be removed from a future version of CMake."
-# It's produced by GTest and likely Google benchmark.
-set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
-
 # Fix warning for FetchContent_Declare regarding DOWNLOAD_EXTRACT_TIMESTAMP
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
     cmake_policy(SET CMP0135 NEW)
@@ -50,7 +45,7 @@ if (SUITABLE_STRUCT_NEED_GTEST AND NOT TARGET gtest)
 
         FetchContent_Declare(
             googletest
-            URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
+            URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
         )
 
         FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
Update GTest and fix macOS CI build and Qt installation to address failures on the latest macOS GitHub Actions image.

The latest macOS GitHub Actions image introduced breaking changes. This PR updates GTest to v1.15.2 and removes a deprecated CMake warning workaround to fix build errors. It also resolves the "externally-managed-environment" error during Qt installation by configuring `install-qt-action` to manage its own Python, and adds `CMAKE_OSX_ARCHITECTURES=x86_64` for correct macOS compilation.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d53050c-c64d-44cf-8281-323cb88017bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d53050c-c64d-44cf-8281-323cb88017bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

