### PR TITLE
Update CI to Qt 6.8.3, fix deprecated API and header include cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         os: [linux]
         compiler: [gcc, clang]
         test_libs: [tl_preinstalled, tl_missing]
-        qt: [qt_no, qt_5.15.2, qt_6.6.1]
+        qt: [qt_no, qt_5.15.2, qt_6.8.3]
         build_type: [Debug, Release]
 
     runs-on: ubuntu-latest
@@ -58,9 +58,17 @@ jobs:
       matrix:
         compiler_arch: [x64]
         qt_arch: [win64_msvc2019_64]
-        qt: [qt_no, 5.15.2, 6.6.1]
+        qt: [qt_no, 5.15.2]
         build_type: [Debug, Release]
         include:
+          - compiler_arch: x64
+            qt_arch: win64_msvc2022_64
+            qt: 6.8.3
+            build_type: Debug
+          - compiler_arch: x64
+            qt_arch: win64_msvc2022_64
+            qt: 6.8.3
+            build_type: Release
           - compiler_arch: Win32
             qt_arch: win32_msvc2019
             qt: 5.15.2
@@ -116,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qt: [qt_no, 5.15.2, 6.6.1]
+        qt: [qt_no, 5.15.2, 6.8.3]
         build_type: [Debug, Release]
 
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
     runs-on: [ubuntu-latest]
 
     container:
-      image: ihordrachuk/id-build-env:linux-clang-tl_missing-qt_5.15.2-codechecker
+      image: ihordrachuk/id-build-env:linux-clang-tl_missing-qt_6.8.3-codechecker
       options: --workdir ${{ github.workspace }}
 
     steps:

--- a/headers/SuitableStruct/Internals/DefaultTypes.h
+++ b/headers/SuitableStruct/Internals/DefaultTypes.h
@@ -17,7 +17,6 @@
 #include <SuitableStruct/BufferReader.h>
 #include <SuitableStruct/Internals/Helpers.h>
 #include <SuitableStruct/Exceptions.h>
-#include <SuitableStruct/Serializer.h>
 #include <SuitableStruct/Handlers.h>
 
 #ifdef SUITABLE_STRUCT_HAS_QT_LIBRARY

--- a/headers/SuitableStruct/Internals/FwdDeclarations.h
+++ b/headers/SuitableStruct/Internals/FwdDeclarations.h
@@ -19,6 +19,7 @@ template<typename T> Buffer ssSaveInternal(const T& obj);
 template<typename T> void ssLoad(BufferReader& bufferReader, T& obj, SSLoadMode loadMode = SSLoadMode::Protected);
 template<typename T> [[nodiscard]] T ssLoadRet(BufferReader& bufferReader, SSLoadMode loadMode = SSLoadMode::Protected);
 template<typename T> [[nodiscard]] T ssLoadInternalRet(BufferReader& bufferReader);
+template<typename T> void ssLoadInternal(BufferReader& bufferReader, T& obj);
 
 
 template<typename T> QJsonValue ssJsonSave(const T& obj, bool protectedMode = true);

--- a/src/Internals/DefaultTypes.cpp
+++ b/src/Internals/DefaultTypes.cpp
@@ -223,13 +223,28 @@ void ssLoadImpl(BufferReader& bufferReader, QDateTime& value)
     const auto time = ssLoadImplRet<QTime>(bufferReader);
 
     switch (timeSpec) {
-        case Qt::LocalTime: [[fallthrough]];
-        case Qt::UTC:
+        case Qt::LocalTime:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            value = QDateTime(date, time);
+#else
             value = QDateTime(date, time, timeSpec);
+#endif // QT_VERSION
+            break;
+
+        case Qt::UTC:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            value = QDateTime(date, time, QTimeZone::UTC);
+#else
+            value = QDateTime(date, time, timeSpec);
+#endif // QT_VERSION
             break;
 
         case Qt::OffsetFromUTC:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            value = QDateTime(date, time, QTimeZone::fromSecondsAheadOfUtc(std::get<OffsetFromUtc>(timeDetails)));
+#else
             value = QDateTime(date, time, timeSpec, std::get<OffsetFromUtc>(timeDetails));
+#endif // QT_VERSION
             break;
 
         case Qt::TimeZone:
@@ -569,14 +584,29 @@ void ssJsonLoadImpl(const QJsonValue& src, QDateTime& value)
     const auto time = ssJsonLoadImplRet<QTime>(obj["time"]);
 
     switch (timeSpec) {
-        case Qt::LocalTime: [[fallthrough]];
-        case Qt::UTC:
+        case Qt::LocalTime:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            value = QDateTime(date, time);
+#else
             value = QDateTime(date, time, timeSpec);
+#endif // QT_VERSION
+            break;
+
+        case Qt::UTC:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            value = QDateTime(date, time, QTimeZone::UTC);
+#else
+            value = QDateTime(date, time, timeSpec);
+#endif // QT_VERSION
             break;
 
         case Qt::OffsetFromUTC: {
             const auto offsetFromUtc = ssJsonLoadImplRet<OffsetFromUtc>(obj["offset-from-UTC"]);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            value = QDateTime(date, time, QTimeZone::fromSecondsAheadOfUtc(offsetFromUtc));
+#else
             value = QDateTime(date, time, timeSpec, offsetFromUtc);
+#endif // QT_VERSION
             break;
         }
 

--- a/tests/test/test05_serialization.cpp
+++ b/tests/test/test05_serialization.cpp
@@ -138,9 +138,15 @@ TEST(SuitableStruct, SerializationTest_DateTime)
     const std::vector<QDateTime> testData {
         QDateTime::currentDateTime(),
         QDateTime::currentDateTimeUtc(),
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        QDateTime(date, time),
+        QDateTime(date, time, QTimeZone::UTC),
+        QDateTime(date, time, QTimeZone::fromSecondsAheadOfUtc(60*60*2)),
+#else
         QDateTime(date, time, Qt::LocalTime),
         QDateTime(date, time, Qt::UTC),
         QDateTime(date, time, Qt::OffsetFromUTC, 60*60*2),
+#endif // QT_VERSION
         QDateTime(date, time, QTimeZone("America/New_York")),
         QDateTime(date, time, QTimeZone("sdfgihdsfg"))
     };

--- a/tests/test/test10_json.cpp
+++ b/tests/test/test10_json.cpp
@@ -317,9 +317,15 @@ TEST(SuitableStruct, JsonSerialization_DateTime)
     const std::vector<QDateTime> testData {
         QDateTime::currentDateTime(),
         QDateTime::currentDateTimeUtc(),
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        QDateTime(date, time),
+        QDateTime(date, time, QTimeZone::UTC),
+        QDateTime(date, time, QTimeZone::fromSecondsAheadOfUtc(60*60*2)),
+#else
         QDateTime(date, time, Qt::LocalTime),
         QDateTime(date, time, Qt::UTC),
         QDateTime(date, time, Qt::OffsetFromUTC, 60*60*2),
+#endif // QT_VERSION
         QDateTime(date, time, QTimeZone("America/New_York")),
         QDateTime(date, time, QTimeZone("sdfgihdsfg"))
     };


### PR DESCRIPTION
## Summary
- Update CI to use Qt 6.8.3 (from 6.5.3)
- Update CodeChecker Docker image to `qt_6.8.3-codechecker`
- Fix Qt 6.8+ deprecated `QDateTime` constructors — use `QDateTime(QDate, QTime)` with explicit `QTimeZone::UTC`
- Fix `misc-header-include-cycle` between `DefaultTypes.h` and `Serializer.h` — add missing `ssLoadInternal` forward declaration, remove circular include

## Test plan
- [x] MSVC (Windows) build + tests pass
- [x] Clang 20 (Docker, Linux) build + tests pass
- [x] CodeChecker: 0 `misc-header-include-cycle` findings